### PR TITLE
updated keymap

### DIFF
--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,3 @@
+/cache
+/project.local.yml
+/project.yml

--- a/keyboards/cannonkeys/adelie/keymaps/joeblackwaslike/keymap.c
+++ b/keyboards/cannonkeys/adelie/keymaps/joeblackwaslike/keymap.c
@@ -29,32 +29,68 @@ enum layer_names {
     _FN3
 };
 
+#define SFT_LBRC LSFT_T(KC_LBRC)
+#define SFT_RBRC RSFT(KC_RBRC)
+#define ALL_BSPC ALL_T(KC_BSPC)
+
+#define L2_TAB LT(2,KC_TAB)
+
+#define CTL_A LCTL_T(KC_A)
+#define ALT_S LALT_T(KC_S)
+#define GUI_D LGUI_T(KC_D)
+#define SFT_F LSFT_T(KC_F)
+#define ALL_G ALL_T(KC_G)
+#define ALL_H ALL_T(KC_H)
+#define SFT_J RSFT_T(KC_J)
+#define GUI_K RGUI_T(KC_K)
+#define ALT_L RALT_T(KC_L)
+#define CTL_SCLN RCTL_T(KC_SCLN)
+
+#define L2_ENT LT(2,KC_ENT)
+
+#define CTL_ESC LCTL_T(KC_ESC)
+#define L1_SPC LT(1,KC_SPC)
+
+
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-	[_BASE] = LAYOUT_all(
-        KC_GESC, KC_Q, KC_W, KC_E, KC_R, KC_T, KC_Y, KC_U, KC_I, KC_O, KC_P, KC_LBRC, KC_RBRC, KC_BSPC, KC_VOLU,
-        KC_TAB, KC_A, KC_S, KC_D, KC_F, KC_G, KC_H, KC_J, KC_K, KC_L, KC_SCLN, KC_QUOT, KC_ENT, KC_VOLD,
-        KC_LSFT, KC_Z, KC_X, KC_C, KC_V, KC_B, KC_N, KC_M, KC_COMM, KC_DOT, KC_SLSH, KC_RSFT, KC_UP, KC_MUTE,
-        KC_LCTL, KC_LALT, KC_LGUI, MO(_FN1), LT(_FN2, KC_SPC), KC_RGUI, KC_RALT, KC_RCTL, KC_LEFT, KC_DOWN, KC_RGHT
+    [_BASE] = LAYOUT_all(
+        KC_GRV, KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,   KC_O,   KC_P,     SFT_LBRC, SFT_RBRC,   ALL_BSPC,   KC_VOLU,
+        L2_TAB, CTL_A,  ALT_S,  GUI_D,  SFT_F,  ALL_G,  ALL_H,  SFT_J,  GUI_K,  ALT_L,  CTL_SCLN, KC_QUOT,  L2_ENT,                 KC_VOLD,
+        SC_LSPO,KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM,KC_DOT, KC_SLSH,  SC_RSPC,              KC_UP,      KC_MUTE,
+        CTL_ESC,KC_LALT,KC_LGUI,        L1_SPC,                 L1_SPC,         KC_RGUI,KC_RALT,  KC_RCTL,  KC_LEFT,    KC_DOWN,    KC_RGHT
     ),
-	[_FN1] = LAYOUT_all(
-        KC_GRV, KC_EXLM, KC_AT, KC_HASH, KC_DLR, KC_PERC, KC_CIRC, KC_AMPR, KC_ASTR, KC_MINS, KC_PLUS, KC_ASTR, KC_EQL, KC_BSLS, KC_BRIU,
-        _______, KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, KC_7, KC_8, KC_9, KC_0, KC_MINS, KC_EQL, KC_BRID,
-        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_PGUP, RESET,
-        _______, _______, _______, _______, _______, _______, _______, _______, KC_HOME, KC_PGDN, KC_END
+
+    [_FN1] = LAYOUT_all(
+        KC_ESC, KC_EXLM,KC_AT,  KC_HASH,KC_DLR, KC_PERC,KC_CIRC,KC_AMPR,KC_ASTR,KC_LPRN,KC_RPRN,  KC_UNDS, KC_PLUS, KC_PIPE, KC_BRIU,
+        KC_TRNS, KC_1,  KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,   KC_9,   KC_0,     KC_MINS, KC_EQL,  KC_BRID,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,KC_TRNS,  KC_BSLS, KC_TRNS, KC_PGUP, KC_CAPS,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, LGUI(KC_LBRC),    KC_PGDN, LGUI(KC_RBRC)
     ),
-	[_FN2] = LAYOUT_all(
-        _______, KC_F13, KC_F14, KC_F15, KC_F16, KC_F17, KC_F18, KC_F19, KC_F20, KC_F21, KC_F22, KC_F23, KC_F24, _______, RGB_TOG,
-        _______, KC_F1, KC_F2, KC_F3, KC_F4, KC_F5, KC_F6, KC_F7, KC_F8, KC_F9, KC_F10, KC_F11, KC_F12, RGB_MOD,
-        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, RGB_VAI, RGB_SPI,
-        _______, _______, _______, _______, _______, _______, _______, _______, RGB_HUD, RGB_VAD, RGB_HUI
+
+    [_FN2] = LAYOUT_all(
+        QK_BOOT,KC_F13, KC_F14, KC_F15, KC_F16, KC_F17, KC_F18, KC_F19, KC_F20, KC_F21, KC_F22,   KC_F23,  KC_F24,  KC_TRNS, RGB_TOG, KC_TRNS,
+        KC_F1,  KC_F2,  KC_F3,  KC_F4,  KC_F5,  KC_F6,  KC_F7,  KC_F8,  KC_F9,  KC_F10, KC_F12,   KC_TRNS, RGB_MOD, KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,RGB_VAI,RGB_SPI,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS,KC_TRNS,KC_TRNS,RGB_HUD,RGB_VAD,RGB_HUI
     ),
+
     [_FN3] = LAYOUT_all(
-        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
-        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
-        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
-        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______
+        KC_TRNS, KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_SPC,  KC_TRNS, KC_TRNS, KC_TRNS, MO(1), KC_TRNS, KC_TRNS, KC_TRNS
     )
 };
+
+const key_override_t grave_esc_override = ko_make_basic(MOD_MASK_GUI, KC_GRV, KC_ESC);
+
+const uint16_t PROGMEM toggle_layer_1_on[] = {KC_VOLU, KC_VOLD, COMBO_END};
+const uint16_t PROGMEM toggle_layer_1_off[] = {KC_BRIU, KC_BRID, COMBO_END};
+combo_t key_combos[] = {
+    COMBO(toggle_layer_1_on, TG(1)),
+    COMBO(toggle_layer_1_off, TG(1)), // keycodes with modifiers are possible too!
+};
+
 
 const rgblight_segment_t PROGMEM my_layer0_layer[] = RGBLIGHT_LAYER_SEGMENTS(
     {0, 3, HSV_RED}


### PR DESCRIPTION
<!---

    If you are submitting a Vial-enabled keymap for a keyboard in QMK:

    - Keymaps will not be accepted with VIAL_INSECURE=yes.
    - Avoid changing keyboard-level code if possible. (ex: switching the encoder pins in info.json)
    - Please name your keymap "vial". Personal keymaps are not accepted at this time.
      - If your Vial keymap only works for a specific keyboard revision, place it under that revision's folder. (ex: keyboards/planck/rev6_drop/keymaps/vial and keyboards/planck/ez/glow/keymaps/vial)

    If you are submitting a new keyboard with keymaps:

    - If you are also submitting this keyboard to QMK, please try to submit mostly the same code to both repos if possible.
    - If you are not submitting this keyboard to QMK, only include "default" and "vial" keymaps. VIA firmware can no longer be built by this repository.

    ------

    For all keyboard and keymap submissions:

    As the submitter, you are ultimately responsible for maintaining the keyboards/keymaps you submit.
    Vial contributors will try to fix compilation issues as updates are made, but are not always familiar with and often can't test specific keymaps/keyboards.

    Vial is decentralized, so inclusion in the vial-qmk repository is optional. Unmaintained keymaps/keyboards which are broken and cannot be fixed without extensive rework or strong familiarity with the hardware may be removed from this repository, with or without warning.

    ------

    For core changes, please explain what you are changing and why.

    Before submitting a PR, delete the entirety of this comment and document your changes.
-->

## Summary by Sourcery

Update the Adelie joeblackwaslike keymap with new layer-tap and home-row modifier bindings, expanded function layers, and combo-based layer toggles.

Enhancements:
- Introduce custom tap/hold macros, shift brackets, and mirrored space controls to streamline the base typing layer.
- Revise FN layers with updated symbols, navigation shortcuts, RGB controls, and bootloader access.
- Add combo definitions and a GUI-escape override to provide faster access to layer toggling and escape behavior.